### PR TITLE
Add Jekyll template

### DIFF
--- a/jekyll-quickstart/app/.idx/dev.nix
+++ b/jekyll-quickstart/app/.idx/dev.nix
@@ -1,0 +1,56 @@
+# To learn more about how to use Nix to configure your environment
+# see: https://developers.google.com/idx/guides/customize-idx-env
+{ pkgs, ... }: {
+  # Which nixpkgs channel to use.
+  channel = "stable-24.05"; # or "unstable"
+  # Use https://search.nixos.org/packages to find packages
+  packages = [
+    # Jekyll requirements
+    pkgs.ruby
+    pkgs.bundler
+    pkgs.gcc
+    pkgs.gnumake
+    pkgs.jekyll
+  ];
+  # Sets environment variables in the workspace
+  env = { };
+  idx = {
+    # Search for the extensions you want on https://open-vsx.org/ and use "publisher.id"
+    extensions = [ ];
+    # Enable previews
+    previews = {
+      enable = true;
+      previews = {
+        web = {
+          # Build the site and make it available on a local server
+          # nix-shell -p bundler --run "bundle exec jekyll serve"
+          command = [
+            "nix-shell"
+            "-p"
+            "bundler"
+            "--run"
+            "bundle exec jekyll serve --port $PORT"
+          ];
+          manager = "web";
+          env = {
+            PORT = "$PORT";
+          };
+        };
+      };
+    };
+    # Workspace lifecycle hooks
+    workspace = {
+      # Runs when a workspace is first created
+      onCreate = {
+        # Create a new Jekyll site at project root position
+        jekyll-create = "jekyll new . --force";
+        # Install gems into local
+        gem-install = "nix-shell -p bundler --run \"bundle install --gemfile=Gemfile\"";
+        # Open editors for the following files by default, if they exist:
+        default.openFiles = [ ".idx/dev.nix" "README.md" ];
+      };
+      # Runs when the workspace is (re)started
+      onStart = { };
+    };
+  };
+}

--- a/jekyll-quickstart/app/README.md
+++ b/jekyll-quickstart/app/README.md
@@ -1,0 +1,18 @@
+# Jekyll Quickstart Template
+
+Installed all prerequisites for a Jekyll project. More information at: https://jekyllrb.com/docs/
+
+<a href="https://idx.google.com/new?template=https%3A%2F%2Fgithub.com%2Fproject-idx%2Fcommunity-templates%2Ftree%2Fmain%2Fjekyll-quickstart">
+  <picture>
+    <source
+      media="(prefers-color-scheme: dark)"
+      srcset="https://cdn.idx.dev/btn/try_dark_32.svg">
+    <source
+      media="(prefers-color-scheme: light)"
+      srcset="https://cdn.idx.dev/btn/try_light_32.svg">
+    <img
+      height="32"
+      alt="Try in IDX"
+      src="https://cdn.idx.dev/btn/try_purple_32.svg">
+  </picture>
+</a>

--- a/jekyll-quickstart/idx-template.json
+++ b/jekyll-quickstart/idx-template.json
@@ -1,0 +1,6 @@
+{
+    "name": "Jekyll",
+    "description": "A quickstart template for a Jekyll project",
+    "icon": "https://www.gstatic.com/images/branding/productlogos/idx/v1/192px.svg",
+    "params": []
+}

--- a/jekyll-quickstart/idx-template.nix
+++ b/jekyll-quickstart/idx-template.nix
@@ -1,0 +1,6 @@
+{ pkgs, ... }: {
+  bootstrap = ''
+    cp -rf ${./app} "$out"
+    chmod -R +w "$out"
+  '';
+}


### PR DESCRIPTION
Dear maintainers,

I have been using IDX since last month and have greatly appreciated the accessibility it offers. During this time, I also took the opportunity to learn how to set up and run a Jekyll-based blog website.

As a result, I created a template that includes all the requirements, allowing users to start a basic Jekyll website immediately upon setup.

Inside the template, I added a "Try in IDX" button set to the URL of the community repo, instead of mine.

If anyone want to test it out before this template is merged. You can use this: https://idx.google.com/new?template=https%3A%2F%2Fgithub.com%2FDKAMX%2Fproject-idx_community-templates%2Ftree%2Fmain%2Fjekyll-quickstart

I appreciate your consideration.